### PR TITLE
Add proxy config and network client

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,19 @@ Once you have your key, you can provide it in one of the following ways:
 1. **Environment variable**  
    Set `OPENAI_API_KEY` in your shell or system environment.
 
-   ```bash
-   export OPENAI_API_KEY=sk-...
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+## 🌐 Proxy Configuration
+
+Edit `utils/config.py` to set `PROXY_HOST` and `PROXY_PORT` if you need to
+use an HTTP proxy:
+
+```python
+PROXY_HOST = "proxy.example.com"
+PROXY_PORT = 8080
+```
 
 ## 🧙 About
 

--- a/interface/cli.py
+++ b/interface/cli.py
@@ -5,6 +5,7 @@ from core.chat_engine import generate_response, load_identity
 from interface.ptt_loop import enter_ptt_mode
 from audio.tts import speak_response
 from utils.config import CONTEXT_WINDOW_SIZE, SPEAK_OUT
+from utils.network import get_proxy_client
 from tzlocal import get_localzone
 from datetime import datetime
 import openai
@@ -28,7 +29,8 @@ def run():
     # Embedding model used for similarity search
     model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
     # OpenAI client handles chat and speech API calls
-    client = openai.OpenAI(api_key=get_api_key())
+    client = openai.OpenAI(api_key=get_api_key(),
+                           http_client=get_proxy_client())
 
     print("\n🚀 FAISS Memory Chat Started! Type 'exit' to quit.\n")
 

--- a/structure_20250503.txt
+++ b/structure_20250503.txt
@@ -39,6 +39,8 @@ buddy_project/
 │   │   ├── IDENTITY_FILE          # Path for identity pickle
 │   │   ├── CONTEXT_WINDOW_SIZE    # Max number of chat lines to keep
 │   │   └── SPEAK_OUT              # Global voice output toggle
+│   │   ├── PROXY_HOST             # Optional HTTP proxy host
+│   │   └── PROXY_PORT             # Optional HTTP proxy port
 │
 ├── data/ (optional, for file storage)
 │   ├── faiss_index.bin

--- a/utils/config.py
+++ b/utils/config.py
@@ -12,4 +12,8 @@ IDENTITY_FILE    = os.path.join(DATA_DIR, "identity.pkl")
 CONTEXT_WINDOW_SIZE = 1000  # how many messages to keep in chat history
 SPEAK_OUT = True             # enable TTS by default
 
+# HTTP proxy settings (optional)
+PROXY_HOST = None   # e.g. "proxy.example.com"
+PROXY_PORT = None   # e.g. 8080
+
 os.makedirs(DATA_DIR, exist_ok=True)

--- a/utils/network.py
+++ b/utils/network.py
@@ -1,0 +1,12 @@
+"""HTTP client helpers."""
+
+from httpx import Client
+from .config import PROXY_HOST, PROXY_PORT
+
+
+def get_proxy_client() -> Client:
+    """Return an httpx.Client using proxy settings when configured."""
+    if PROXY_HOST and PROXY_PORT:
+        return Client(proxies=f"http://{PROXY_HOST}:{PROXY_PORT}")
+    return Client()
+


### PR DESCRIPTION
## Summary
- add `PROXY_HOST` and `PROXY_PORT` defaults to `utils/config.py`
- provide a `get_proxy_client` helper in new `utils/network.py`
- use proxy aware client in `interface/cli.py`
- document proxy usage in README
- note new options in project structure document

## Testing
- `python -m py_compile utils/network.py`
- `python -m py_compile interface/cli.py`
- `find . -name "*.py" | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_68405a846ccc832298230863a34f15b0