### PR TITLE
Add configurable local LLM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ PROXY_HOST = "proxy.example.com"
 PROXY_PORT = 8080
 ```
 
+## 🔄 Using Local LLMs
+
+To chat with a local OpenAI-compatible server like **LM Studio** or
+**Ollama**, edit `utils/config.py`:
+
+```python
+# Example for LM Studio running on the default port
+CHAT_BASE_URL = "http://localhost:1234/v1"
+CHAT_MODEL = "your-local-model-name"
+```
+
+Set `CHAT_BASE_URL` to the server's base URL and `CHAT_MODEL` to the desired
+model name. Leave `CHAT_BASE_URL` as `None` to use OpenAI.
+
 ## 🧙 About
 
 Modularized and upgraded from a monolithic prototype.  

--- a/core/chat_engine.py
+++ b/core/chat_engine.py
@@ -2,7 +2,7 @@
 
 import os
 from datetime import datetime
-from utils.config import IDENTITY_FILE
+from utils.config import IDENTITY_FILE, CHAT_MODEL
 from tzlocal import get_localzone
 import pickle
 
@@ -64,9 +64,9 @@ Reference retrieved memory only if relevant, or if you want to take the conversa
 Ensure responses feel continuous and time-aware.
 """
 
-    # Send the full prompt to GPT-4o to get the assistant's reply
+    # Send the full prompt to the configured chat model
     response = client.chat.completions.create(
-        model="gpt-4o",
+        model=CHAT_MODEL,
         messages=[
             {"role": "system", "content": f"{default_prompt} You are an AI assistant with memory."},
             {"role": "user", "content": ai_prompt}

--- a/interface/ptt_loop.py
+++ b/interface/ptt_loop.py
@@ -11,7 +11,7 @@ import re
 
 local_tz = get_localzone()
 
-def enter_ptt_mode(index, metadata, identity_info, model, client, chat_history, speak_out=True):
+def enter_ptt_mode(index, metadata, identity_info, model, openai_client, chat_client, chat_history, speak_out=True):
     """Interactive push-to-talk loop using the microphone."""
     print("🎙️ PTT Mode ON — Hold spacebar to speak. Release to stop. Press Enter to send, or type 'cancel'. Type !ptt_off to exit.")
 
@@ -32,7 +32,7 @@ def enter_ptt_mode(index, metadata, identity_info, model, client, chat_history, 
             continue
 
         # Convert recorded audio to text using OpenAI Whisper API
-        user_transcript = transcribe_audio(client)
+        user_transcript = transcribe_audio(openai_client)
         print(f"👤 Transcribed Input: {user_transcript}")
         decision = input("✅ Press Enter to send, or type 'cancel' to discard: ").strip().lower()
         if decision == "cancel":
@@ -45,7 +45,7 @@ def enter_ptt_mode(index, metadata, identity_info, model, client, chat_history, 
         # Retrieve relevant past conversation to provide context
         embedding = model.encode([user_transcript], convert_to_numpy=True)
         retrieved_text = retrieve_context(index, metadata, embedding)
-        response = generate_response(user_transcript, identity_info, retrieved_text, chat_history, client)
+        response = generate_response(user_transcript, identity_info, retrieved_text, chat_history, chat_client)
 
         print("🔍 FAISS Retrieved Memory:")
         # print(retrieved_text)
@@ -63,7 +63,7 @@ def enter_ptt_mode(index, metadata, identity_info, model, client, chat_history, 
                 tts_instructions = "Speak naturally."
             # Play the response audio asynchronously
             import threading
-            threading.Thread(target=speak_response, args=(response,client,tts_instructions), daemon=True).start()
+            threading.Thread(target=speak_response, args=(response,openai_client,tts_instructions), daemon=True).start()
 
         now_str = datetime.now(local_tz).strftime("%Y-%m-%d %I:%M %p %Z")
         # Maintain chat history window for later context

--- a/utils/config.py
+++ b/utils/config.py
@@ -17,3 +17,9 @@ PROXY_HOST = None   # e.g. "proxy.example.com"
 PROXY_PORT = None   # e.g. 8080
 
 os.makedirs(DATA_DIR, exist_ok=True)
+
+# Chat LLM configuration
+# ``CHAT_BASE_URL`` can point to a local OpenAI-compatible server such as
+# LM Studio or Ollama. When ``None`` (the default), OpenAI's servers are used.
+CHAT_BASE_URL = None  # e.g. "http://localhost:1234/v1" for LM Studio
+CHAT_MODEL = "gpt-4o"

--- a/utils/llm.py
+++ b/utils/llm.py
@@ -1,0 +1,29 @@
+"""LLM client utilities."""
+
+import os
+import openai
+from .network import get_proxy_client
+from .config import CHAT_BASE_URL
+from .keys import get_api_key
+
+
+def get_chat_client() -> openai.OpenAI:
+    """Return an OpenAI-compatible client for chat completions.
+
+    Uses ``CHAT_BASE_URL`` from config to connect to a local LLM if set.
+    For OpenAI's API, uses the regular ``OPENAI_API_KEY`` environment variable.
+    """
+    kwargs = {"http_client": get_proxy_client()}
+    if CHAT_BASE_URL:
+        kwargs["base_url"] = CHAT_BASE_URL
+        # Local servers typically don't require an API key but the OpenAI
+        # client expects one, so provide a placeholder if none is set.
+        kwargs["api_key"] = os.getenv("OPENAI_API_KEY", "local-api-key")
+    else:
+        kwargs["api_key"] = get_api_key()
+    return openai.OpenAI(**kwargs)
+
+
+def get_openai_client() -> openai.OpenAI:
+    """Return a client that always targets OpenAI's servers."""
+    return openai.OpenAI(api_key=get_api_key(), http_client=get_proxy_client())


### PR DESCRIPTION
## Summary
- allow switching chat model via `CHAT_BASE_URL` and `CHAT_MODEL`
- implement `utils.llm` for creating chat/openai clients
- update CLI and PTT logic to use separate clients for chat vs. TTS/Whisper
- document how to use LM Studio or Ollama

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_685467ee5b388322a23c62bfbedd6cd8