### PR TITLE
Enhance Postgres memory retrieval with context and diversity

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,43 @@ BuddyChat-V2 is a modular, voice-powered AI assistant built with OpenAI’s GPT-
 
 ---
 
+🧠 Memory Retrieval v2 (Postgres + Contextual MMR)
+BuddyChat’s memory system now supports context-rich and diverse retrieval using PostgreSQL and vector embeddings.
+
+Key Enhancements
+Contextual Snippets
+Retrieved memories now include surrounding conversation turns, creating coherent and emotionally aware results.
+
+Noise Filtering
+Messages that are too short, or contain only emojis, are filtered out to improve quality.
+
+Maximal Marginal Relevance (MMR)
+Memory hits are ranked for both relevance and diversity, reducing repetition and surfacing a broader spectrum of useful context.
+
+Penalty Adjustments
+
+Short messages: small penalty
+
+Emoji-heavy messages: additional penalty
+These help downrank less informative entries during scoring.
+
+Retrieval Flow
+Vector similarity search via PostgreSQL
+
+Penalty-adjusted scoring (length, emojis)
+
+MMR post-processing to select top-N diverse results
+
+Surrounding context rows fetched and included
+
+Configured Thresholds
+SHORT_LENGTH_THRESHOLD = 30
+SHORT_PENALTY = 0.05
+EMOJI_PENALTY_WEIGHT = 0.02
+RELEVANCE_THRESHOLD = 1.0
+
+---
+
 ## 🛠️ Setup
 > Requires Python 3.10–3.13 (tested on 3.13.1)
 

--- a/core/pg_memory.py
+++ b/core/pg_memory.py
@@ -2,75 +2,138 @@ import psycopg2
 import numpy as np
 from datetime import datetime
 from typing import List
-from db.database import get_pg_connection, fetch_similar_messages, insert_message_row  # DB helpers
+from db.database import (
+    get_pg_connection,
+    fetch_similar_messages,
+    insert_message_row,
+    fetch_message_context,
+)  # DB helpers
 
 # --- CONFIG ---
 EMBEDDING_DIM = 768
 
 # --- Penalty Parameters ---
 TOP_K = 100
-RELEVANCE_THRESHOLD = 1 #0.24
+RELEVANCE_THRESHOLD = 1  # 0.24
 SHORT_LENGTH_THRESHOLD = 30
 SHORT_PENALTY = 0.05
 EMOJI_PENALTY_WEIGHT = 0.02
 EMOJIS = ["😲", "😘", "💋", "😍", "😳", "😌"]
 
+
+def is_meaningful(text: str) -> bool:
+    """Filter out short or low-information strings (e.g., emoji-only)."""
+    stripped = text.strip()
+    if len(stripped) < SHORT_LENGTH_THRESHOLD:
+        return False
+    alnum = sum(ch.isalnum() for ch in stripped)
+    if alnum / max(len(stripped), 1) < 0.3:
+        return False
+    return True
+
+
+def mmr(
+    query_vec: np.ndarray,
+    candidates: List[dict],
+    top_n: int,
+    lambda_param: float = 0.75,
+) -> List[dict]:
+    """Maximal Marginal Relevance for diversity."""
+    selected = []
+    candidates = candidates.copy()
+    q_norm = query_vec / (np.linalg.norm(query_vec) + 1e-10)
+    for c in candidates:
+        emb = c["embedding"]
+        c["norm_emb"] = emb / (np.linalg.norm(emb) + 1e-10)
+        c["query_sim"] = float(np.dot(c["norm_emb"], q_norm))
+
+    while candidates and len(selected) < top_n:
+        if not selected:
+            idx = int(np.argmax([c["query_sim"] for c in candidates]))
+        else:
+            for c in candidates:
+                sim_selected = max(
+                    float(np.dot(c["norm_emb"], s["norm_emb"])) for s in selected
+                )
+                c["mmr_score"] = lambda_param * c["query_sim"] - (
+                    1 - lambda_param
+                ) * sim_selected
+            idx = int(np.argmax([c["mmr_score"] for c in candidates]))
+        selected.append(candidates.pop(idx))
+
+    return selected
+
 # --- BGE-Compatible Embedding Wrapper ---
 def get_embedding(embed_model, role: str, content: str, timestamp: datetime) -> np.ndarray:
-    """
-    Format message according to BGE embedding best practices, then embed.
-    """
     role_formatted = role.capitalize()
     ts_str = timestamp.strftime("%Y-%m-%d %H:%M")
     enriched_text = f"[{ts_str}] {role_formatted}: {content.strip()}"
     prompt = f"Represent this sentence for retrieval: {enriched_text}"
     return embed_model.encode(prompt)
 
-
-# --- Main Memory Search ---
-def get_embedding(embed_model, role: str, content: str, timestamp: datetime) -> np.ndarray:
-    role_formatted = role.capitalize()
-    ts_str = timestamp.strftime("%Y-%m-%d %H:%M")
-    enriched_text = f"[{ts_str}] {role_formatted}: {content.strip()}"
-    prompt = f"Represent this sentence for retrieval: {enriched_text}"
-    return embed_model.encode(prompt)
-
-def search_memory(conn, embed_model, user_input: str, table_name: str = "Messages", top_n: int = 6) -> list[str]:
+def search_memory(
+    conn, embed_model, user_input: str, table_name: str = "Messages", top_n: int = 6
+) -> list[str]:
     now = datetime.utcnow()
-    query_embedding = get_embedding(embed_model, "user", user_input, now).tolist()
+    query_vec = get_embedding(embed_model, "user", user_input, now)
 
-    raw_results = fetch_similar_messages(conn, table_name, query_embedding, top_k=TOP_K)
+    raw_results = fetch_similar_messages(
+        conn, table_name, query_vec.tolist(), top_k=TOP_K
+    )
 
-    scored_results = []
-
-    for role, content, ts, distance in raw_results:
+    candidates = []
+    for (
+        msg_id,
+        convo_id,
+        role,
+        content,
+        ts,
+        emb,
+        distance,
+    ) in raw_results:
         content = content.strip().replace("\n", " ")
-
+        if not is_meaningful(content):
+            continue
         length_penalty = SHORT_PENALTY if len(content) < SHORT_LENGTH_THRESHOLD else 0
         emoji_count = sum(content.count(e) for e in EMOJIS)
         emoji_penalty = 0 if len(content) > 100 else EMOJI_PENALTY_WEIGHT * emoji_count
         adjusted = distance + length_penalty + emoji_penalty
-
         if adjusted > RELEVANCE_THRESHOLD:
             continue
+        candidates.append(
+            {
+                "id": msg_id,
+                "conversation_id": convo_id,
+                "role": role,
+                "content": content,
+                "timestamp": ts,
+                "embedding": np.array(emb, dtype=float),
+                "adjusted": adjusted,
+            }
+        )
 
-        formatted = f"{role.capitalize()} ({ts:%Y-%m-%d %I:%M %p}): {content}"
-        scored_results.append((adjusted, formatted))
+    diversified = mmr(query_vec, candidates, top_n)
 
-    # Sort by adjusted score (lower is better) and return top N
-    scored_results.sort(key=lambda x: x[0])
-    # Deduplicate results
-    seen = set()
+    snippets = []
+    for c in diversified:
+        context_rows = fetch_message_context(
+            conn, c["conversation_id"], c["timestamp"], window=1
+        )
+        lines = [
+            f"{r.capitalize()} ({t:%Y-%m-%d %I:%M %p}): {s.strip().replace('\n', ' ')}"
+            for r, s, t in context_rows
+        ]
+        snippet = "\n".join(lines)
+        snippets.append(snippet)
+
     deduped = []
-    for _, text in scored_results:
+    seen = set()
+    for text in snippets:
         key = text.lower().strip()
         if key in seen:
             continue
         seen.add(key)
         deduped.append(text)
-        if len(deduped) >= top_n:
-            break
-
     return deduped
 
 

--- a/core/pg_memory.py
+++ b/core/pg_memory.py
@@ -1,5 +1,6 @@
 import psycopg2
 import numpy as np
+import json
 from datetime import datetime
 from typing import List
 from db.database import (
@@ -100,6 +101,12 @@ def search_memory(
         adjusted = distance + length_penalty + emoji_penalty
         if adjusted > RELEVANCE_THRESHOLD:
             continue
+        if isinstance(emb, str):
+            try:
+                emb = json.loads(emb)
+            except json.JSONDecodeError:
+                emb = [float(x) for x in emb.strip("[]{} ").split(",") if x.strip()]
+        emb_array = np.array(emb, dtype=float)
         candidates.append(
             {
                 "id": msg_id,
@@ -107,7 +114,7 @@ def search_memory(
                 "role": role,
                 "content": content,
                 "timestamp": ts,
-                "embedding": np.array(emb, dtype=float),
+                "embedding": emb_array,
                 "adjusted": adjusted,
             }
         )

--- a/db/database.py
+++ b/db/database.py
@@ -19,16 +19,56 @@ def fetch_similar_messages(
     table_name: str,
     embedding: List[float],
     top_k: int = 6
-) -> List[Tuple[str, str, datetime]]:
+) -> List[Tuple[str, str, str, datetime, List[float], float]]:
+    """Fetch messages ordered by vector distance, returning metadata and embeddings."""
     with conn.cursor() as cur:
-        cur.execute(f"""
-            SELECT author_role, content, timestamp, embedding <-> %s::vector AS distance
+        cur.execute(
+            f"""
+            SELECT id, conversation_id, author_role, content, timestamp, embedding,
+                   embedding <-> %s::vector AS distance
             FROM {table_name}
             WHERE embedding IS NOT NULL
             ORDER BY embedding <-> %s::vector
             LIMIT %s
-        """, (embedding, embedding, top_k))
+            """,
+            (embedding, embedding, top_k),
+        )
         return cur.fetchall()
+
+
+def fetch_message_context(
+    conn,
+    conversation_id: str,
+    timestamp: datetime,
+    window: int = 1,
+) -> List[Tuple[str, str, datetime]]:
+    """Return surrounding messages within the same conversation for context."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT author_role, content, timestamp
+            FROM messages
+            WHERE conversation_id = %s AND timestamp < %s
+            ORDER BY timestamp DESC
+            LIMIT %s
+            """,
+            (conversation_id, timestamp, window),
+        )
+        prev_rows = cur.fetchall()[::-1]
+
+        cur.execute(
+            """
+            SELECT author_role, content, timestamp
+            FROM messages
+            WHERE conversation_id = %s AND timestamp >= %s
+            ORDER BY timestamp ASC
+            LIMIT %s
+            """,
+            (conversation_id, timestamp, window + 1),
+        )
+        next_rows = cur.fetchall()
+
+    return prev_rows + next_rows
 
 # --- INSERT Wrapper ---
 def insert_message_row(

--- a/db/database.py
+++ b/db/database.py
@@ -19,7 +19,7 @@ def fetch_similar_messages(
     table_name: str,
     embedding: List[float],
     top_k: int = 6
-) -> List[Tuple[str, str, str, datetime, List[float], float]]:
+) -> List[Tuple[str, str, str, str, datetime, List[float], float]]:
     """Fetch messages ordered by vector distance, returning metadata and embeddings."""
     with conn.cursor() as cur:
         cur.execute(


### PR DESCRIPTION
## Summary
- Expand Postgres query helpers to return message metadata and nearby context
- Filter out short or emoji-only snippets and diversify results with Maximal Marginal Relevance
- Retrieve surrounding messages for each hit to provide richer context

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68973f847cd883229780210068bb725c